### PR TITLE
Add Rewrite Rule for `integerSquareRoot'` on `Natural`

### DIFF
--- a/Math/NumberTheory/Roots/Squares.hs
+++ b/Math/NumberTheory/Roots/Squares.hs
@@ -57,6 +57,7 @@ integerSquareRoot n
 "integerSquareRoot'/Int"     integerSquareRoot' = isqrtInt'
 "integerSquareRoot'/Word"    integerSquareRoot' = isqrtWord
 "integerSquareRoot'/Integer" integerSquareRoot' = isqrtInteger
+"integerSquareRoot'/Natural" integerSquareRoot' = fromInteger . isqrtInteger . toInteger
   #-}
 {-# INLINE [1] integerSquareRoot' #-}
 integerSquareRoot' :: Integral a => a -> a


### PR DESCRIPTION
Currently, using `integerSquareRoot` on `Natural` does not benefit from the improved performance of `isqrtInteger` which uses `karatsubaSqrt`. This adds a rewrite rule to use `isqrtInteger` to implement `integerSquareRoot'` on `Natural`.